### PR TITLE
valgrind changes

### DIFF
--- a/ExtModeForMain.cpp
+++ b/ExtModeForMain.cpp
@@ -194,7 +194,6 @@ SPPoint** NonExtractionModeAct(char* directory, char* imagePrefix,
 	int* numOfFeatArray = (int*) malloc(sizeof(int) * spNumOfImages);
 	if(!numOfFeatArray){
 		printf("failed to allocate memory\n");
-
 		return NULL;
 	}
 	int totalNumOfFeat = 0;

--- a/ExtModeForMain.cpp
+++ b/ExtModeForMain.cpp
@@ -194,6 +194,7 @@ SPPoint** NonExtractionModeAct(char* directory, char* imagePrefix,
 	int* numOfFeatArray = (int*) malloc(sizeof(int) * spNumOfImages);
 	if(!numOfFeatArray){
 		printf("failed to allocate memory\n");
+
 		return NULL;
 	}
 	int totalNumOfFeat = 0;

--- a/SPConfig.c
+++ b/SPConfig.c
@@ -206,6 +206,7 @@ bool spHandleStringProperty(char** property, bool* propertyCheck, char* value, S
 		return false;
 	}
 	*property = malloc((strlen(value) + 1) * sizeof(char));
+	//TODO this variable is not freed properly.
 	if(!(*property)){
 		*msg = SP_CONFIG_ALLOC_FAIL;
 		return false;
@@ -317,6 +318,7 @@ bool spHandleSuffixProperty(char** property, bool* propertyCheck, char* value, S
 	if((strcmp(value, ".jpg") == 0) || (strcmp(value, ".png") == 0) ||
 	   (strcmp(value, ".bmp") == 0) || (strcmp(value, ".gif") == 0)){
 		*property = malloc((strlen(value) + 1) * sizeof(char));
+		//TODO this variable is not freed properly.
 		if(!(*property)){
 			*msg = SP_CONFIG_ALLOC_FAIL;
 			return false;

--- a/SPKDTree.c
+++ b/SPKDTree.c
@@ -62,7 +62,7 @@ KDTreeNode* spInitKDTreeNode(int dim, double val, KDTreeNode* left, KDTreeNode* 
 
 	if(!left && !right && data != NULL)
 	{
-		kdNode -> data = spPointCopy(data);
+		kdNode -> data = data;
 	}
 	else if( (left!= NULL || right!= NULL) && !data ){
 		kdNode -> data = NULL;
@@ -295,6 +295,9 @@ KDTreeNode* spInitSPKDTreeRec(SPKDArray kdArray, SP_KD_SPLIT_MODE splitMethod, i
 		free(leftAndRight);
 		return NULL;
 	}
+	spDestroyKDArray(leftAndRight[0]);
+	spDestroyKDArray(leftAndRight[1]);
+	free(leftAndRight);
 	return spInitKDTreeNode(splitDim, median, leftNode, rightNode, NULL);
 
 }
@@ -327,8 +330,13 @@ void spDestroyKDTree(SPKDTree* tree){
 	if(!tree){
 		return;
 	}
+	if(tree->root){
 	spDestroyKDTreeNode(tree->root);
+	}
+	if(tree->features){
 	spDestroyKDArray(tree->features);
+	}
+	free(tree);
 }
 
 void inOrderScanRootPoints (KDTreeNode* node){

--- a/main.cpp
+++ b/main.cpp
@@ -303,7 +303,7 @@ int main(int argc, const char* argv[]) {
             spDestroyKDTree(tree);
             spDestroySPPointArray(features, totalNumOfFeatures);
             spLoggerDestroy();
-            free(config);
+            spConfigDestroy(config);
             return 9;
         }
         if(strcmp(queryStr, "<>") == 0){
@@ -323,7 +323,7 @@ int main(int argc, const char* argv[]) {
                 spDestroyKDTree(tree);
                 spDestroySPPointArray(features, totalNumOfFeatures);
                 spLoggerDestroy();
-                free(config);
+                spConfigDestroy(config);
                 return 9;
             }
             free(KNN);
@@ -334,7 +334,7 @@ int main(int argc, const char* argv[]) {
     spDestroyKDTree(tree);
     spDestroySPPointArray(features, totalNumOfFeatures);
     spLoggerDestroy();
-    free(config);
+    spConfigDestroy(config);
     return 0;
 }
 

--- a/spcbir.config
+++ b/spcbir.config
@@ -1,0 +1,17 @@
+#this is a valid configuration file
+#The following variables don’t have default values and must be set
+spImagesDirectory = ./unit_tests/RotatedEx3plusProj
+spImagesPrefix=imag
+spImagesSuffix = .png
+spNumOfImages = 17 
+#the following variables have default values, if not set the default value is choosen
+# spPCADimension = 20 -> notice the default value is chosen since this is a comment
+spPCAFilename = pca.yml
+spNumOfFeatures = 100 
+spExtractionMode = true 
+#spMinimalGUI = true -> the default value is chosen since this is a comment
+spNumOfSimilarImages = 5
+spLoggerFilename = stdout
+spKDTreeSplitMethod = MAX_SPREAD
+spLoggerLevel = 3
+spKNN = 1


### PR DESCRIPTION
Free the variables marked with TODO in config.
Switch the : free(config) to destroy in the config file, maybe in main if there are any left.
---
I will change extmode tomorrow - need to free the gallery on failure.
Otherwise most of the errors come from opencv - I ran it with lower variables in the config file to make it faster, but couldn't really see any more memory leaks beside the opencv ones... but maybe its the hour.